### PR TITLE
Allow Markdown-style local links to be resolved

### DIFF
--- a/src/UmbMarkdown/UmbMarkdownPropertyValueConverter.cs
+++ b/src/UmbMarkdown/UmbMarkdownPropertyValueConverter.cs
@@ -53,7 +53,19 @@ namespace UmbMarkdown
         /// <inheritdoc/>
         public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
         {
-            return new HtmlString(source == null ? string.Empty : Markdown.ToHtml(source.ToString(), this.pipeline));
+            if (source == null)
+            {
+                return new HtmlString(string.Empty);
+            }
+
+            var result = Markdown.ToHtml(source.ToString(), this.pipeline);
+            if (UmbracoContext.Current != null)
+            {
+                result = TemplateUtilities.ParseInternalLinks(result);
+                result = TemplateUtilities.ResolveUrlsFromTextString(result);
+            }
+
+            return new HtmlString(result);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
The default template function only resolves local links present in `href` attributes.
This allows to also resolve Markdown-style local links, like `[Some link text]({localLink:umb://document/<id>})`

Fixes #4